### PR TITLE
Docker compose

### DIFF
--- a/api/Dockerfile.db
+++ b/api/Dockerfile.db
@@ -1,5 +1,0 @@
-FROM mysql:9.0.1
-
-
-EXPOSE 3306
-ENV MYSQL_ROOT_PASSWORD=passw0rd

--- a/api/README.md
+++ b/api/README.md
@@ -32,13 +32,7 @@ The database is a MySQL database running on a docker instance. For this tep you 
 From the `api` directory run:
 
 ```
-docker build --file Dockerfile.db -t cooking-app-db .
-```
-
-This will create your DB docker image. To run the image, run:
-
-```
-docker run --name my-app-db -p 3306:3306 cooking-app-db
+docker compose up
 ```
 
 You should now be able to connect to the MySQL server hosted on the docker container, create your database and all the tables you need.

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  cooking-app-db:
+    image: mysql:latest
+    container_name: mysql-server
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
We don't need to build the docker image here since we're just using it to expose a port. Using a docker compose file lets us store the configuration from the run command too. I don't think it's an issue to leak the root password in the compose file for this project.